### PR TITLE
Change complex search separator to semicolon for easier post processing

### DIFF
--- a/godap/simplesearch.go
+++ b/godap/simplesearch.go
@@ -63,7 +63,7 @@ func ParseLDAPSimpleSearchRequestPacket(p *ber.Packet) (*LDAPSimpleSearchRequest
                 childVal := getContextValue(child)
                 if childVal != "" {
                     if ret != "" {
-                        ret += ","
+                        ret += ";"
                     }
                     ret += childVal
                 }
@@ -77,7 +77,7 @@ func ParseLDAPSimpleSearchRequestPacket(p *ber.Packet) (*LDAPSimpleSearchRequest
             value := getContextValue(rps[index])
             if value != "" {
                 if ret.FilterValue != "" {
-                    ret.FilterValue += ","
+                    ret.FilterValue += ";"
                 }
                 ret.FilterValue += value
             }


### PR DESCRIPTION
If a search request other than a simple like `(uid=<name>)` e.g. `(&(uid=<name>)(memberOf=cn=some,ou=groups,dc=example,dc=com))` is used the value of `ret.FilterValue` will become e.g. `uid,<name>,memberOf,cn=some,ou=groups,dc=example,dc=com`.
Splitting this at `,` would lead to more elements than expected. With this change the separator is changed to `;` to get `uid;<name>;memberOf;cn=some,ou=groups,dc=example,dc=com`